### PR TITLE
Add Suede to Developer Showcases — x402-paid music/video API

### DIFF
--- a/README.md
+++ b/README.md
@@ -199,6 +199,8 @@ Not sure which protocols to use? Answer these questions to get your recommended 
 - **[Multi-Agent Coordination](link)** - A2A + multiple payment rails
 
 ### 🎯 Developer Showcases
+- **[Suede](https://app.suedeai.xyz)** — x402-paid AI music + video generation. Live `402` challenges on `/agent/generate`, `/create-music`, `/agent/video`. Discovery via `/.well-known/x402` + `/.well-known/agent-card.json`. ACP-ready commerce intent endpoint. USDC on Base. ([endpoint reference](https://github.com/Suede-AI/suede-x402-acp))
+
 *Submit your project: [Contribution Guidelines](./community/CONTRIBUTING.md)*
 
 ---


### PR DESCRIPTION
Adds Suede to **Ecosystem Projects → Developer Showcases**.

Suede is x402-paid AI music + video generation with on-chain ownership infrastructure — fits squarely in Layer 4: Commerce.

- Live app: https://app.suedeai.xyz
- OSS reference: https://github.com/Suede-AI/suede-x402-acp
- Live `402` challenges on: `/agent/generate`, `/create-music`, `/agent/video`
- Discovery: `/.well-known/x402`, `/.well-known/agent-card.json`
- USDC on Base; ACP-ready commerce intent endpoint