### PR TITLE
Add ERC-8004 (Layer 1 Identity) and ERC-8183 (Layer 4 Commerce) to the stack

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,6 +56,7 @@ graph TB
 | **W3C DIDs/Verifiable Credentials** | Decentralized identity foundation | Open standards | ✅ Standard |
 | **Mastercard "Know Your Agent"** | TradFi-to-agent identity bridge | Card network integration | 🚧 Pilot |
 | **Salesforce Agent Cloud** | Enterprise agent identity management | CRM-integrated workflows | **NEW 2025** |
+| **ERC-8004 (Trustless Agents)** | On-chain agent identity + reputation registries | Permissionless, EVM-native, signed feedback | ✅ Production (Base) |
 
 ### 📍 Layer 2: Discovery (The "Yellow Pages")  
 *How do agents find each other and discover services?*
@@ -86,6 +87,7 @@ graph TB
 | **Visa TAP** | Visa + x402 Foundation | TradFi + crypto bridge | Agent verification, x402 compatibility | **NEW 2025** |
 | **Pay3** | Pay3 Platform | Stablecoin automation | USDC/USDT, autonomous payouts | Telegram/TON focus |
 | **Agent Pay** | Mastercard | TradFi integration | Tokenized payments, wallet integration | Global card networks |
+| **ERC-8183 (Agentic Commerce)** | EIP / community | Agent-to-agent service-delivery escrow | On-chain escrow + evaluator + 8004 reputation feedback | ✅ Production (Base) |
 
 ---
 
@@ -127,6 +129,7 @@ Not sure which protocols to use? Answer these questions to get your recommended 
 - **🛒 Consumer AI Commerce** → ACP (OpenAI/Stripe) + MCP
 - **🌐 Cross-Chain DeFi Agents** → Pay3 + Olas + MCP
 - **💳 Traditional Finance Integration** → Mastercard Agent Pay + AP2
+- **🤝 Agent-to-Agent Service Delivery (with escrow)** → ERC-8183 + ERC-8004 + x402
 
 ### 🏗️ What's your technical background?
 - **Web2 Developer** → Start with ACP (Stripe) + MCP

--- a/protocols/commerce.md
+++ b/protocols/commerce.md
@@ -11,6 +11,7 @@ The commerce layer enables agents to exchange value through various payment mech
 | **ACP** | OpenAI + Stripe | Consumer AI commerce | Seamless ChatGPT checkout experience | ✅ Production |
 | **Pay3** | Pay3 Platform | Stablecoin automation | Autonomous USDC/USDT transactions | 🚧 Beta |
 | **Mastercard Agent Pay** | Mastercard | TradFi integration | Tokenized payments via card networks | 🚧 Pilot |
+| **ERC-8183 Agentic Commerce** | EIP / community | Agent-to-agent service-delivery escrow | On-chain escrow + evaluator + reputation feedback | ✅ Production (Base) |
 
 ---
 
@@ -354,6 +355,45 @@ const securePaymentConfig = {
   }
 };
 ```
+
+---
+
+## 🤝 ERC-8183 — Agentic Commerce (Service-Delivery Escrow)
+
+### Overview
+[ERC-8183](https://eips.ethereum.org/EIPS/eip-8183) defines an on-chain escrow standard for *service delivery* between agents, distinct from the *micropayment* use case x402 handles. Where x402 settles instantly per HTTP request, ERC-8183 holds funds in escrow across a Job lifecycle so the buyer (Client) and seller (Provider) can disagree about whether the deliverable is acceptable, with an Evaluator role resolving disputes on-chain.
+
+```
+Client ──createJob──▶ Provider ──approve──▶ Client ──fund (escrow)──▶
+Provider ──submit (deliverable URI)──▶ Evaluator ──complete | reject──▶
+splits paid on-chain (provider / evaluator / platform) + ERC-8004 feedback
+```
+
+### Why It Complements x402
+x402 is correct for **stateless metered access** (per-request micropayments). ERC-8183 is correct for **stateful work products** where:
+- The deliverable can't be verified by a 200 OK
+- A neutral third party may need to adjudicate
+- Both sides want a public, tamper-evident trail of who did what
+- Reputation feedback should auto-fire on settlement (and it does — ERC-8183 contracts can write directly to ERC-8004 ReputationRegistry on completion)
+
+### Key Features
+- **On-chain escrow in stablecoin** (USDC on the reference deployment)
+- **3-way fee splits** enforced by the contract (provider / evaluator / platform)
+- **Pluggable evaluator policies**: manual review, JSON-schema validation, HTTP health-check; deterministic auto-finalize loops
+- **Refund on expiry** so funds are never stuck if the provider goes silent
+- **Native reputation reflux**: completion writes an `erc8183_job` feedback event to ERC-8004 with no extra integration
+
+### Reference Implementation
+- **CardZero** runs the first known production deployment on Base mainnet (since 2026-05):
+  - Jobs (proxy): [`0xb28a0cca5ac28466f3d175f35b97aa104d4c4ba8`](https://basescan.org/address/0xb28a0cca5ac28466f3d175f35b97aa104d4c4ba8)
+  - V3 wallet factory (escrow-aware ERC-4337): [`0x0c1d37f49ab9da5b6da2e2938be5567fbba4aabb`](https://basescan.org/address/0x0c1d37f49ab9da5b6da2e2938be5567fbba4aabb)
+  - Live API: `POST/GET https://api.cardzero.ai/v1/jobs`
+  - End-to-end mainnet trace (1 USDC, 5 transactions, 93/5/2% split): see [cardzero.ai/docs/recipes/job-escrow](https://cardzero.ai/docs/recipes/job-escrow)
+  - Source + 133 unit tests: [github.com/mrocker/CardZero](https://github.com/mrocker/CardZero)
+
+### Links
+- Spec: <https://eips.ethereum.org/EIPS/eip-8183>
+- Discussion: <https://ethereum-magicians.org/t/erc-8183-agentic-commerce/27902>
 
 ---
 

--- a/protocols/identity-trust.md
+++ b/protocols/identity-trust.md
@@ -11,6 +11,44 @@ The identity and trust layer is the foundation of the agentic economy. Before ag
 | **W3C DIDs/VCs** | W3C Standards | Decentralized identity foundation | Self-sovereign identity for agents | ✅ Standard |
 | **Mastercard "Know Your Agent"** | Mastercard | TradFi-to-agent identity bridge | Card network integration + compliance | 🚧 Pilot |
 | **IBM Agent Identity Framework** | IBM | Enterprise agent identity | Corporate identity integration | 🔄 Development |
+| **ERC-8004 Trustless Agents** | EIP / community | On-chain identity + reputation registries | Permissionless, EVM-native, signed feedback | ✅ Production (Base) |
+
+---
+
+## 🪪 ERC-8004 — Trustless Agents (Identity & Reputation Registries)
+
+### Overview
+[ERC-8004](https://eips.ethereum.org/EIPS/eip-8004) defines two minimal on-chain registries for autonomous agents on EVM chains:
+
+1. **Identity Registry** — assigns each agent a globally unique `agentId` and binds it to a wallet address + a metadata URI (the "Agent Card", typically served at `/.well-known/agent-card.json`).
+2. **Reputation Registry** — accepts signed `feedback` events (value `[-10, 20]`, scoring rules pinned by `scoringRulesHash`) so any seller, evaluator, or peer can build a portable, public track record for an agent.
+
+Unlike VC-based identity systems (AP2, W3C VCs) that depend on a recognized issuer, ERC-8004 is **permissionless**: any agent can register, any party can publish feedback, and consumers decide whose feedback to trust off-chain.
+
+### Key Features
+- **Permissionless identity**: no gatekeeper; agentId is monotonic and bound to the registering address
+- **EIP-712 signed feedback**: feedback events are off-chain-verifiable and tamper-evident
+- **ERC-1271 contract signatures supported**: smart-contract wallets can attest natively
+- **`scoringRulesHash`**: pins the consumer-readable rules under which feedback was issued, so buyers know what a "score 15" actually meant
+- **Composable with commerce**: ERC-8183 escrow contracts can write reputation events directly on settlement
+
+### Reference Implementation
+- **CardZero** runs the first known production deployment on Base mainnet (since 2026-05):
+  - IdentityRegistry: [`0x1db9b790ae49def806d3d16172de04d2557fecbe`](https://basescan.org/address/0x1db9b790ae49def806d3d16172de04d2557fecbe)
+  - ReputationRegistry: [`0xc00a5757c63d65005d22e507eae045df5e83b338`](https://basescan.org/address/0xc00a5757c63d65005d22e507eae045df5e83b338)
+  - Public Agent Card endpoints: `GET https://cardzero.ai/.well-known/agent/<wallet>`
+  - Scoring rules: [cardzero.ai/SCORING-RULES.md](https://cardzero.ai/SCORING-RULES.md)
+  - Source + tests: [github.com/mrocker/CardZero](https://github.com/mrocker/CardZero)
+
+### Use Cases
+- x402 sellers checking an agent's payment-history reputation before serving
+- Agent-to-agent service marketplaces ranking providers
+- Lighthouse evaluators cross-referencing past job outcomes
+- Any context where you want trust signals without a centralized issuer
+
+### Links
+- Spec: <https://eips.ethereum.org/EIPS/eip-8004>
+- Discussion: <https://ethereum-magicians.org/t/erc-8004-trustless-agents/27922>
 
 ---
 


### PR DESCRIPTION
This PR adds two recent EIP/community standards to the existing 4-layer stack:

### 🪪 Layer 1: Identity & Trust → add **ERC-8004 (Trustless Agents)**

Existing entries (AP2 mandates, Visa TAP, W3C VCs, KYA, Salesforce Agent Cloud) all assume a recognized credential issuer. [ERC-8004](https://eips.ethereum.org/EIPS/eip-8004) is the *issuer-less* counterpart for EVM-native agents:
- Permissionless on-chain identity (any agent can register; gets a monotonic `agentId` + Agent Card URI)
- Permissionless reputation (any party can publish EIP-712-signed feedback in `[-10, 20]`, with `scoringRulesHash` pinning the rules)
- ERC-1271 contract-signature support so smart-contract wallets can attest natively

### 💰 Layer 4: Commerce → add **ERC-8183 (Agentic Commerce)**

The existing Layer 4 table covers the *micropayment* case well (x402 for HTTP-native pay-per-request, AP2 for VC-authorized payments, ACP for ChatGPT checkout). It does not yet cover **agent-to-agent service delivery** — the case where the deliverable can't be verified by a 200 OK and a neutral Evaluator may need to adjudicate.

[ERC-8183](https://eips.ethereum.org/EIPS/eip-8183) is the on-chain escrow standard that fills that gap:
- Stablecoin escrow held in-contract through `createJob → approve → fund → submit → complete | reject` lifecycle
- 3-way fee splits (provider / evaluator / platform) enforced by the contract
- Pluggable evaluator policies (manual / JSON schema / HTTP check) + auto-finalize
- Refund-on-expiry so funds are never stuck
- Native composition with Layer 1: ERC-8183 contracts can write `erc8183_job` feedback directly into ERC-8004 ReputationRegistry on settlement, so reputation reflects real economic outcomes — no extra integration work.

### Reference implementation cited

Both sections cite a **public production deployment on Base mainnet** (since 2026-05) as the concrete reference implementation, with on-chain proxy addresses, the published `scoringRulesHash`, an end-to-end traced lifecycle, and the open-source repo. This gives readers something runnable today rather than a spec-only entry.

### Files changed
- `README.md` (3 lines): one row in Layer 1 table, one row in Layer 4 table, one bullet in the "Choose Your Use Case" selector
- `protocols/identity-trust.md` (38 lines): one table row + a full ERC-8004 section in the existing per-protocol-deep-dive style
- `protocols/commerce.md` (40 lines): one table row + a full ERC-8183 section in the existing per-protocol-deep-dive style

No content removed; no existing entries reordered or rewritten.

### Disclosure

I'm one of the maintainers of the cited reference implementation. I'm proposing the two **standards** be added to the list (they're independent EIPs); the reference implementation is just a citation so readers have something runnable. Happy to drop the implementation links and keep only the EIP spec links if the maintainers prefer that.
