### PR TITLE
Add AgentIAM (Achilles EP) to Developer Showcases

### DIFF
--- a/README.md
+++ b/README.md
@@ -199,6 +199,9 @@ Not sure which protocols to use? Answer these questions to get your recommended 
 - **[Multi-Agent Coordination](link)** - A2A + multiple payment rails
 
 ### 🎯 Developer Showcases
+
+- **[AgentIAM (Achilles EP)](https://achillesalpha.com)** — Pre-execution safety + intelligence layer for autonomous agents. 18 x402-payable HTTP endpoints on Base Mainnet (NoLeak / MemGuard / RiskOracle / SecureExec / FlowCore for execution safety; code audit / validate; research; DELPHI knowledge graph; real-time signals). $0.001–$0.05 USDC/call. Indexed on [x402scan](https://www.x402scan.com/server/de9dbadb-6475-43f2-a621-a805fb1c661e), [402index](https://402index.io), and the [MCP Registry](https://registry.modelcontextprotocol.io/v0/servers?search=agentiam).
+
 *Submit your project: [Contribution Guidelines](./community/CONTRIBUTING.md)*
 
 ---


### PR DESCRIPTION
Adds **AgentIAM (Achilles EP)** to the Developer Showcases section.

**AgentIAM** is the agent-economy safety primitive layer: 18 x402-payable HTTP endpoints on Base Mainnet covering execution integrity, state verification, risk scoring, sandboxed execution, full orchestration, code audit, validate, research, DELPHI intelligence + knowledge graph, and real-time signals. $0.001–$0.05 USDC/call.

Slots into your 4-Layer Stack as **Layer 1 (Identity & Trust)** + **Layer 2 (Discovery)** for safety-aware agents:
- Layer 1: pre-action risk + execution integrity proofs
- Layer 2: discoverable via [/.well-known/x402](https://achillesalpha.com/.well-known/x402), [/.well-known/agent.json](https://achillesalpha.com/.well-known/agent.json), [/.well-known/mcp.json](https://achillesalpha.com/.well-known/mcp.json)
- Layer 4: native x402 commerce on Base Mainnet, USDC

Visibility:
- x402scan: https://www.x402scan.com/server/de9dbadb-6475-43f2-a621-a805fb1c661e (18/18 resources)
- 402index: https://402index.io (14 listings)
- MCP Registry: https://registry.modelcontextprotocol.io/v0/servers?search=agentiam