### PR TITLE
Add Gapup MCP as Developer Showcase — 185-tool agent-payable C-suite MCP

### DIFF
--- a/README.md
+++ b/README.md
@@ -201,6 +201,8 @@ Not sure which protocols to use? Answer these questions to get your recommended 
 ### 🎯 Developer Showcases
 *Submit your project: [Contribution Guidelines](./community/CONTRIBUTING.md)*
 
+- **[Gapup MCP](https://github.com/getgapup/gapup-mcp-public)** — 183-tool agent-payable MCP server for board-ready C-suite intelligence. Competitive intel (EDGAR + Yahoo + Wayback), SEC filings, 8-list sanctions screener (OFAC + EU + UK + UN + SECO + SEMA + DFAT), KYC, pentest scope, clinical evidence GRADE-graded (PubMed + ClinicalTrials.gov + OpenFDA), EU-first real estate (DVF Cerema + Géorisques), NAICS classifier, sentiment news (GDELT), research paper Q&A (OpenAlex 45M). Pay-per-call x402 USDC/EURC on Base + Optimism. Free tier 100 calls/mo. Dual-audience format (human Mistral / agent Cerebras <5s). [Smithery verified ✓](https://smithery.ai/servers/gapup-team/gapup-mcp) · [Live endpoint](https://mcp.gapup.io/mcp) · [Onboard](https://hub.gapup.io/agents-api/onboard)
+
 ---
 
 ## 👥 Community & Resources


### PR DESCRIPTION
## Adding Gapup MCP to Developer Showcases

Hi @xpaysh 👋

Submitting Gapup MCP as a Developer Showcase — a hosted **185-tool MCP server** providing 100+ board-ready C-suite expertises for AI agents, paying via x402 USDC/EURC on Base + Optimism.

### What makes it agentic-economy native
- **x402 native** — pay-per-call $0.002 (T0 atomic) → $1.50 (T6 async batch flagship)
- **Multi-chain** — USDC + EURC on Base + Optimism
- **Free tier** — 100 calls/mo no credit card (real free tier, not a paywall demo)
- **Dual-audience format** — `audience` param routes agent (Cerebras <5s) vs human (Mistral board-ready ~30s)
- **Source-grounded** — every clinical evidence cite has DOI, every research paper has author+year+journal+DOI, every sanctions hit has list+date+match_type

### Tool breakdown (185 total)
- **Competitive intelligence** — EDGAR + Yahoo + Wayback multi-source deep-dive
- **SEC filing decoder** — 10-K / 10-Q / 8-K extraction + red flags + M&A signals
- **8-list sanctions screener** — OFAC + EU + UK + UN + SECO + SEMA + DFAT + adverse media
- **Clinical evidence GRADE-graded** — PubMed + ClinicalTrials.gov + OpenFDA
- **EU-first real estate** — DVF Cerema + Géorisques (regulatory-grade)
- **Research paper Q&A** — OpenAlex 45M + Semantic Scholar + CORE, DOI-cited
- **Industry classifier** — NAICS + SIC + NACE + GICS + ISIC + HS hierarchy
- **Sentiment news pulse** — GDELT crisis detection
- **Plus 90+ more** — KYC, pentest scope, attack surface, infra design, AI Act audits, etc.

### Verification
- ✅ Smithery verified: https://smithery.ai/servers/gapup-team/gapup-mcp
- ✅ Live endpoint: `https://mcp.gapup.io/mcp` (Streamable HTTP MCP)
- ✅ Public repo: https://github.com/getgapup/gapup-mcp-public (manifests + docs + SDK examples)
- ✅ x402 manifest: https://mcp.gapup.io/.well-known/x402

Contact: agents@gapup.io
