### PR TITLE
Add YIELD INTELLIGENCE MCP server — Finance/Yield analysis

### DIFF
--- a/README.md
+++ b/README.md
@@ -199,6 +199,8 @@ Not sure which protocols to use? Answer these questions to get your recommended 
 - **[Multi-Agent Coordination](link)** - A2A + multiple payment rails
 
 ### 🎯 Developer Showcases
+- **[YIELD INTELLIGENCE (IntuiTek¹)](https://github.com/thebrierfox/intuitek-ace)** - Live MCP server for passive income analysis: US Treasury rates, portfolio yield calculator, AI income optimizer. $1 USDC/call via x402 on Base. Open endpoint, no auth. In the [official MCP Registry](https://registry.modelcontextprotocol.io/).
+
 *Submit your project: [Contribution Guidelines](./community/CONTRIBUTING.md)*
 
 ---


### PR DESCRIPTION
Adding YIELD INTELLIGENCE to the Model Context Protocol (MCP) section.

What it does: Passive income opportunity analysis with live US Treasury rates, portfolio yield calculator, and AI-powered income optimization for autonomous agents.

Live MCP endpoint: https://api.intuitek.ai/yield/mcp (open, no auth required)

Tools: analyze_yield_opportunities, optimize_income_portfolio

x402 pricing: $1 USDC per call on Base — fits naturally in this list.

Also in the official MCP registry: io.github.thebrierfox/intuitek-ace
