### PR TITLE
feat: add TWZRD Agent Intel to Identity & Trust layer

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,6 +56,7 @@ graph TB
 | **W3C DIDs/Verifiable Credentials** | Decentralized identity foundation | Open standards | ✅ Standard |
 | **Mastercard "Know Your Agent"** | TradFi-to-agent identity bridge | Card network integration | 🚧 Pilot |
 | **Salesforce Agent Cloud** | Enterprise agent identity management | CRM-integrated workflows | **NEW 2025** |
+| **TWZRD Agent Intel** | Solana-native x402 MCP for agent trust scoring -- signed `twzrd.receipt.v5` receipts | On-chain trust verification, <1s settlement | ✅ Production |
 
 ### 📍 Layer 2: Discovery (The "Yellow Pages")  
 *How do agents find each other and discover services?*


### PR DESCRIPTION
Adds **TWZRD Agent Intel** to Layer 1: Identity & Trust.

TWZRD Agent Intel is a production Solana-native agent trust scoring MCP that fits directly in this layer — it answers the question *'Who can I trust?'* using on-chain evidence.

**How it works**:
- 4 free preflight tools: Score any Solana wallet (on-chain activity, transaction patterns, network age, recurring behavior)
- 4 paid tools: HTTP 402 + USDC on Solana (<1s settlement) → signed `twzrd.receipt.v5` trust tokens
- MCP endpoint: `https://intel.twzrd.xyz/mcp`
- MCP Registry: `xyz.twzrd.intel/twzrd-agent-intel`

The signed receipt pattern enables agents to pass trust proofs to each other — a Solana-native take on the 'Know Your Agent' problem described in the Layer 1 overview.