### PR TITLE
Add DoNotAct risk gateway showcase

### DIFF
--- a/README.md
+++ b/README.md
@@ -201,6 +201,8 @@ Not sure which protocols to use? Answer these questions to get your recommended 
 ### 🎯 Developer Showcases
 *Submit your project: [Contribution Guidelines](./community/CONTRIBUTING.md)*
 
+- **[DoNotAct](https://donotact.com)** - Fail-closed Risk Gateway for agents before capital moves. Prediction-market and token agents can call stop/go diagnostics with signed receipts, MCP/OpenAPI discovery, and x402 per-call payment routes for UMA dispute lifecycle, resolution ambiguity, public-book capacity, and T1-T8 token-risk checks.
+
 ---
 
 ## 👥 Community & Resources


### PR DESCRIPTION
Adds DoNotAct as an agentic economy developer showcase: a fail-closed risk gateway with MCP/OpenAPI discovery and x402 paid endpoints for prediction-market and token agents.\n\nThe description avoids ROI/profit claims and focuses on concrete stop/go/pay-per-call surfaces: UMA dispute lifecycle, resolution ambiguity, public-book capacity, T1-T8 token-risk checks, and signed receipts.