### PR TITLE
Add Packrift UCP merchant fixture

### DIFF
--- a/README.md
+++ b/README.md
@@ -259,6 +259,10 @@ cd x402-vending-machine && npm start         # stablecoin micropayments
 cd ap2-vending-machine && npm start          # verifiable mandates
 ```
 
+### Live merchant fixtures
+
+- [Packrift UCP shipping-supplies merchant](https://mcp.packrift.com/ai/packrift-ucp-shipping-supplies-starter-kit.html) - live Shopify packaging merchant with native UCP catalog/cart/checkout plus no-auth MCP tools for shipping-supplies storefront builders.
+
 Long form: [`use-cases/README.md`](./use-cases/README.md), [`implementations/README.md`](./implementations/README.md).
 
 ---


### PR DESCRIPTION
## Summary

Adds Packrift as a live UCP merchant fixture for builders who want a real shipping-supplies catalog to test against.

## Why this fits

- Packrift is a live Shopify packaging merchant.
- The linked starter kit documents native UCP catalog/cart/checkout plus no-auth MCP tools for packaging discovery and cart handoff.
- It gives builders a concrete merchant source for boxes, mailers, bags, tape, labels, and stretch wrap instead of a toy vending-machine example.

## Checks

- README-only change.
- Link is public and reachable: https://mcp.packrift.com/ai/packrift-ucp-shipping-supplies-starter-kit.html
- No private credentials, no test purchase, no pricing or catalog mutation.
