### PR TITLE
Add acp-sandbox to Conformance and tooling

### DIFF
--- a/README.md
+++ b/README.md
@@ -224,6 +224,7 @@ The negative space. Every entry below has been seen in plugin output or blog pos
 
 ## Conformance and tooling
 
+- [flovoice53-tech/acp-sandbox](https://github.com/flovoice53-tech/acp-sandbox) ([live](https://acp-sandbox.flo-voice1.com)) — hosted mock merchant implementing the ACP `checkout_sessions` lifecycle (create, retrieve, complete, cancel); lets an agent developer test a real checkout integration end to end without a live store or real payment.
 - [Universal-Commerce-Protocol/conformance](https://github.com/Universal-Commerce-Protocol/conformance) — official UCP conformance suite.
 - [`@xpaysh/conformance-fixtures`](https://www.npmjs.com/package/@xpaysh/conformance-fixtures) — golden ACP + UCP request/response payloads cross-validating against canonical schemas via Ajv.
 - [`@xpaysh/storefront-audit`](https://www.npmjs.com/package/@xpaysh/storefront-audit) — `ac-doctor` CLI; audits a live storefront for the discovery surface above.


### PR DESCRIPTION
Adds a merchant-side ACP conformance sandbox to fill the gap next to UCP's official conformance suite.

- **What it is**: a hosted mock merchant implementing the real ACP `checkout_sessions` lifecycle (create/retrieve/complete/cancel), matching the schema in `spec/2026-04-17`. Lets an agent developer test a checkout integration end to end without a live store or real payment.
- **Real and reachable**: live at https://acp-sandbox.flo-voice1.com, source at https://github.com/flovoice53-tech/acp-sandbox, MIT licensed.
- No adoption-count claims made, per the list's own "unverifiable adoption claims get cut" rule — just describing what it does.

Happy to adjust wording/placement if this fits better elsewhere.