### PR TITLE
Add SpendShield — authorization layer for agentic payments

### DIFF
--- a/README.md
+++ b/README.md
@@ -164,6 +164,7 @@ Platforms without a current entry (OpenCart, Shopware, Spree, Sylius, nopCommerc
 | [Universal-Commerce-Protocol/samples](https://github.com/Universal-Commerce-Protocol/samples) | Sample agents + merchants | UCP | mixed | UCP TSC *(official)* |
 | [Universal-Commerce-Protocol/conformance](https://github.com/Universal-Commerce-Protocol/conformance) | Conformance suite | UCP | mixed | UCP TSC *(official)* |
 | [xpaysh/agentic-commerce-plugin-template](https://github.com/xpaysh/agentic-commerce-plugin-template) | Monorepo template | ACP, UCP, AP2 | TypeScript | xpaysh |
+| [SpendShield](https://github.com/felixpg13-glitch/spendshield) | Policy & authorization layer (spending gates) | Any rail (x402 demo) | Python | felixpg13-glitch |
 
 ## Maintainer's npm packages
 


### PR DESCRIPTION
SpendShield is the missing policy/authorization layer for agentic-commerce flows: between an agent's intent to pay and the rail (x402/AP2/ACP-adjacent or traditional), it returns ALLOW / APPROVAL / DENY against budgets, merchant lists and per-transaction caps, issuing a signed single-use grant the executor must verify. Rail-agnostic by design (x402 adapter + MCP server included).

MIT, Python. Happy to adjust the row/format to fit the table conventions.