### PR TITLE
feat: add PrismAgenticPay AP2 policy-authority kernel

### DIFF
--- a/README.md
+++ b/README.md
@@ -164,6 +164,7 @@ Platforms without a current entry (OpenCart, Shopware, Spree, Sylius, nopCommerc
 | [Universal-Commerce-Protocol/samples](https://github.com/Universal-Commerce-Protocol/samples) | Sample agents + merchants | UCP | mixed | UCP TSC *(official)* |
 | [Universal-Commerce-Protocol/conformance](https://github.com/Universal-Commerce-Protocol/conformance) | Conformance suite | UCP | mixed | UCP TSC *(official)* |
 | [xpaysh/agentic-commerce-plugin-template](https://github.com/xpaysh/agentic-commerce-plugin-template) | Monorepo template | ACP, UCP, AP2 | TypeScript | xpaysh |
+| [insightitsGit/prismagenticpay](https://github.com/insightitsGit/prismagenticpay) | Policy-authority kernel: verifies AP2 mandates and reserves budget before Stripe capture | AP2 | Python | insightitsGit |
 
 ## Maintainer's npm packages
 


### PR DESCRIPTION
## Summary
- Add [insightitsGit/prismagenticpay](https://github.com/insightitsGit/prismagenticpay) under Reference implementations and SDKs.

## Acceptance criteria
1. **Real and reachable.** Public repo plus published package: https://pypi.org/project/prismagenticpay/1.4.1/
2. **Speaks AP2.** Verifies signed AP2 payment mandates (ES256 / checkout hash bind) and issues signed authorization decisions before Stripe capture. It is a policy-authority kernel, not a storefront plugin.
3. **Why this matters.** Verifies AP2 mandates and reserves budget before Stripe capture.
4. **License declared.** MIT in the linked repo.
5. **Last commit within 12 months.** Active on `main`.
6. **No adoption claims.** No transaction counts or partner numbers.

## Test plan
- [ ] Confirm the GitHub repo returns 200 to a logged-out visitor
- [ ] Confirm PyPI 1.4.1 is installable
- [ ] Confirm MIT license is present
- [ ] Confirm the table row stays one sentence and does not add vapor or unverifiable metrics